### PR TITLE
Updated to use the new Lua 5.1/5.2 module syntax as the

### DIFF
--- a/fsm.lua
+++ b/fsm.lua
@@ -135,7 +135,7 @@ Have fun !!
 
 --MODULE CODE
 ------------------------------------------------------------------------------- 
-module(..., package.seeall)
+local fsm = {}
 
 -- FSM CONSTANTS --------------------------------------------------------------
 SEPARATOR = '.'
@@ -144,7 +144,7 @@ ANYSTATE  = ANY .. SEPARATOR
 ANYEVENT  = SEPARATOR .. ANY
 UNKNOWN   = ANYSTATE .. ANY
 
-function new(t)
+function fsm.new(t)
 	
 	local self = {}
 	
@@ -226,4 +226,4 @@ function new(t)
 	return self
 end
 
-
+return fsm


### PR DESCRIPTION
current version errors out in Gideros Mobile on Lua 5.1 and beyond.
